### PR TITLE
[#26][#29] [Backend] As a user, I can get the raw HTML of multiple Google & Bing search pages

### DIFF
--- a/app/forms/upload_form.rb
+++ b/app/forms/upload_form.rb
@@ -40,8 +40,9 @@ class UploadForm
   end
 
   def scrape_search_results(results)
-    results.map(&:id).each do |id|
-      SearchKeywordJob.perform_later(id)
+    results.each_with_index do |result, index|
+      delay_in_seconds = 3.seconds * index
+      SearchKeywordJob.set(wait: delay_in_seconds).perform_later(result.id)
     end
   end
 

--- a/app/forms/upload_form.rb
+++ b/app/forms/upload_form.rb
@@ -40,9 +40,9 @@ class UploadForm
   end
 
   def scrape_search_results(results)
-    results.each_with_index do |result, index|
-      delay_in_seconds = 3.seconds * index
-      SearchKeywordJob.set(wait: delay_in_seconds).perform_later(result.id)
+    results.map(&:id).each do |id|
+      delay_in_seconds = rand(1..600).seconds # Maximum delay is 10 minutes
+      SearchKeywordJob.set(wait: delay_in_seconds).perform_later(id)
     end
   end
 

--- a/app/forms/upload_form.rb
+++ b/app/forms/upload_form.rb
@@ -41,9 +41,12 @@ class UploadForm
 
   def scrape_search_results(results)
     results.map(&:id).each do |id|
-      delay_in_seconds = rand(1..600).seconds # Maximum delay is 10 minutes
-      SearchKeywordJob.set(wait: delay_in_seconds).perform_later(id)
+      SearchKeywordJob.set(wait: generate_delay_in_seconds).perform_later(id)
     end
+  end
+
+  def generate_delay_in_seconds
+    rand(1..600).seconds # Maximum delay is 10 minutes
   end
 
   def csv_file_content_type

--- a/app/services/search/google_search_service.rb
+++ b/app/services/search/google_search_service.rb
@@ -6,16 +6,14 @@ module Search
 
     USER_AGENT_HEADER = 'User-Agent'
 
-    X_FORWARDED_FOR_HEADER = 'X-Forwarded-For'
-
     def initialize(keyword, language = 'en')
       @search_url = format(GOOGLE_SEARCH_URL, keyword: keyword, language: language)
     end
 
     def search
-      connection = create_connection(@search_url)
+      uri = URI.parse(@search_url)
 
-      response = connection.get
+      response = Faraday.get(uri, nil, USER_AGENT_HEADER => generate_user_agent)
 
       response.body if response.status == 200
     rescue Faraday::ConnectionFailed
@@ -24,24 +22,8 @@ module Search
 
     private
 
-    def create_connection(search_url)
-      uri = URI.parse(search_url)
-      Faraday.new(url: uri, headers: create_request_header)
-    end
-
-    def create_request_header
-      {
-        USER_AGENT_HEADER => generate_user_agent,
-        X_FORWARDED_FOR_HEADER => generate_ip_address
-      }
-    end
-
     def generate_user_agent
       Ronin::Web::UserAgents.chrome.random
-    end
-
-    def generate_ip_address
-      FFaker::Internet.ip_v4_address
     end
   end
 end

--- a/app/services/search/google_search_service.rb
+++ b/app/services/search/google_search_service.rb
@@ -6,14 +6,16 @@ module Search
 
     USER_AGENT_HEADER = 'User-Agent'
 
+    X_FORWARDED_FOR_HEADER = 'X-Forwarded-For'
+
     def initialize(keyword, language = 'en')
       @search_url = format(GOOGLE_SEARCH_URL, keyword: keyword, language: language)
     end
 
     def search
-      uri = URI.parse(@search_url)
+      connection = create_connection(@search_url)
 
-      response = Faraday.get(uri, nil, USER_AGENT_HEADER => generate_user_agent)
+      response = connection.get
 
       response.body if response.status == 200
     rescue Faraday::ConnectionFailed
@@ -22,8 +24,24 @@ module Search
 
     private
 
+    def create_connection(search_url)
+      uri = URI.parse(search_url)
+      Faraday.new(url: uri, headers: create_request_header)
+    end
+
+    def create_request_header
+      {
+        USER_AGENT_HEADER => generate_user_agent,
+        X_FORWARDED_FOR_HEADER => generate_ip_address
+      }
+    end
+
     def generate_user_agent
       Ronin::Web::UserAgents.chrome.random
+    end
+
+    def generate_ip_address
+      FFaker::Internet.ip_v4_address
     end
   end
 end

--- a/spec/fixtures/files/upload_valid_massive_keywords.csv
+++ b/spec/fixtures/files/upload_valid_massive_keywords.csv
@@ -1,0 +1,295 @@
+smartphone
+laptop
+tablet
+smartwatch
+headphones
+gaming console
+desktop computer
+smart TV
+virtual reality headset
+fitness tracker
+wireless earbuds
+e-reader
+action camera
+portable speaker
+smart home hub
+robot vacuum
+drone
+smart thermostat
+smart doorbell
+smart lock
+gaming mouse
+mechanical keyboard
+graphics card
+smart speaker
+external hard drive
+wireless router
+computer monitor
+smart lighting
+smart plug
+bluetooth earphones
+wireless charging pad
+wearable camera
+smart scale
+smart mirror
+wireless keyboard
+smart projector
+game controller
+smart car charger
+USB flash drive
+webcam
+portable power bank
+bluetooth speaker
+wireless mouse
+smart pen
+smart backpack
+VR gaming headset
+surveillance camera
+smart alarm clock
+thermal printer
+noise-canceling headphones
+gaming headset
+compact camera
+smart oven
+robotic arm
+smart water bottle
+laser printer
+action camcorder
+fitness smartwatch
+in-ear monitors
+smart garden
+smart door lock
+wireless ear hooks
+gaming keyboard
+portable gaming monitor
+gaming chair
+ergonomic mouse
+external SSD
+smart coffee maker
+portable SSD
+WiFi range extender
+robotic vacuum mop
+smart home security system
+robot lawn mower
+gaming headset stand
+ultrawide monitor
+waterproof Bluetooth speaker
+smart air purifier
+smart picture frame
+gaming controller charger
+USB-C hub
+home theater projector
+smart pet feeder
+smart plant pot
+wireless gamepad
+smart thermostat with voice control
+smart window blinds
+WiFi smart plug
+smart key finder
+gaming racing chair
+robotic window cleaner
+wireless gaming headset
+streaming media player
+compact wireless speaker
+portable mini projector
+gaming steering wheel
+smart sleep mask
+Bluetooth gaming mouse
+WiFi mesh system
+wireless gaming keyboard
+smart cat litter box
+smart mirror with built-in display
+portable Bluetooth speaker
+gaming capture card
+robotic pool cleaner
+smart wine opener
+portable gaming laptop
+smart kitchen scale
+smart water leak detector
+gaming desk
+portable Bluetooth keyboard
+smart frying pan
+gaming monitor
+smart ceiling fan
+smart toothbrush
+portable gaming console
+virtual keyboard
+smart window air conditioner
+smart frying pan
+smartphone
+laptop
+tablet
+smartwatch
+headphones
+gaming console
+desktop computer
+smart TV
+virtual reality headset
+fitness tracker
+wireless earbuds
+e-reader
+action camera
+portable speaker
+smart home hub
+robot vacuum
+drone
+smart thermostat
+smart doorbell
+smart lock
+gaming mouse
+mechanical keyboard
+graphics card
+smart speaker
+external hard drive
+wireless router
+computer monitor
+smart lighting
+smart plug
+bluetooth earphones
+wireless charging pad
+wearable camera
+smart scale
+smart mirror
+wireless keyboard
+smart projector
+game controller
+smart car charger
+USB flash drive
+webcam
+portable power bank
+bluetooth speaker
+wireless mouse
+smart pen
+smart backpack
+VR gaming headset
+surveillance camera
+smart alarm clock
+thermal printer
+noise-canceling headphones
+gaming headset
+compact camera
+smart oven
+robotic arm
+smart water bottle
+laser printer
+action camcorder
+fitness smartwatch
+in-ear monitors
+smart garden
+smart door lock
+wireless ear hooks
+gaming keyboard
+portable gaming monitor
+gaming chair
+ergonomic mouse
+external SSD
+smart coffee maker
+portable SSD
+WiFi range extender
+robotic vacuum mop
+smart home security system
+robot lawn mower
+gaming headset stand
+ultrawide monitor
+waterproof Bluetooth speaker
+smart air purifier
+smart picture frame
+gaming controller charger
+USB-C hub
+home theater projector
+smart pet feeder
+smart plant pot
+wireless gamepad
+smart thermostat with voice control
+smart window blinds
+WiFi smart plug
+smart key finder
+gaming racing chair
+robotic window cleaner
+wireless gaming headset
+streaming media player
+compact wireless speaker
+portable mini projector
+gaming steering wheel
+smart sleep mask
+Bluetooth gaming mouse
+WiFi mesh system
+wireless gaming keyboard
+smart cat litter box
+smart mirror with built-in display
+portable Bluetooth speaker
+gaming capture card
+robotic pool cleaner
+smart wine opener
+portable gaming laptop
+smart kitchen scale
+smart water leak detector
+gaming desk
+portable Bluetooth keyboard
+smart frying pan
+gaming monitor
+smart ceiling fan
+smart toothbrush
+portable gaming console
+virtual keyboard
+smart window air conditioner
+smart frying pan
+wireless charging stand
+USB-C cable
+gaming headset holder
+smart radiator valve
+wireless gaming mouse
+gaming graphics card
+smart pet collar
+smart video doorbell
+smart fan
+portable hard drive
+smart meat thermometer
+smart luggage
+USB hub
+gaming mouse pad
+smartphone tripod
+wireless presenter
+smart can opener
+smart notebook
+smart curtain
+portable SSD drive
+gaming laptop cooling pad
+smart garbage can
+Bluetooth receiver
+smart car adapter
+smart coffee mug
+wireless charging car mount
+smart water pitcher
+smart fabric steamer
+smart light switch
+smart vacuum sealer
+smart wine fridge
+portable gaming controller
+smart frying pan
+smart sous vide cooker
+gaming desk chair
+smart baby monitor
+smart bike lock
+wireless charging desk lamp
+smart language translator
+gaming streaming device
+smart makeup mirror
+smart bike helmet
+portable gaming keyboard
+smart luggage tracker
+gaming microphone
+smart pasta maker
+wireless charging table
+smart jump rope
+smart countertop oven
+gaming desk mat
+smart towel warmer
+smart wine dispenser
+wireless charging mouse pad
+smart rice cooker
+smart body analyzer
+gaming racing simulator
+smart pet camera
+smart food scale
+wireless charging

--- a/spec/forms/upload_form_spec.rb
+++ b/spec/forms/upload_form_spec.rb
@@ -90,6 +90,17 @@ RSpec.describe UploadForm, type: :model do
       end
     end
 
+    context 'given valid attributes with massive list of keywords' do
+      it 'runs search keyword jobs with random delay' do
+        upload_form = described_class.new(
+          search_engine: 'google',
+          csv_file: fixture_file_upload('upload_valid_massive_keywords.csv', 'text/csv')
+        )
+
+        expect { upload_form.save }.to have_enqueued_job(SearchKeywordJob).exactly(295).times
+      end
+    end
+
     context 'given any attribute is INVALID' do
       it 'raises an error' do
         upload_form = described_class.new(

--- a/spec/forms/upload_form_spec.rb
+++ b/spec/forms/upload_form_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe UploadForm, type: :model do
           csv_file: fixture_file_upload('upload_valid_massive_keywords.csv', 'text/csv')
         )
 
-        allow_any_instance_of(described_class).to receive(:generate_delay_in_seconds).and_return(5) # rubocop: disable RSpec/AnyInstance
+        allow(upload_form).to receive(:generate_delay_in_seconds).and_return(5)
         allow(Time).to receive(:now).and_return(Time.zone.parse('2023-01-01 00:00:00 +0700'))
 
         expect { upload_form.save }.to have_enqueued_job(SearchKeywordJob).at(5.seconds.from_now).exactly(295).times

--- a/spec/forms/upload_form_spec.rb
+++ b/spec/forms/upload_form_spec.rb
@@ -97,7 +97,10 @@ RSpec.describe UploadForm, type: :model do
           csv_file: fixture_file_upload('upload_valid_massive_keywords.csv', 'text/csv')
         )
 
-        expect { upload_form.save }.to have_enqueued_job(SearchKeywordJob).exactly(295).times
+        allow_any_instance_of(described_class).to receive(:generate_delay_in_seconds).and_return(5) # rubocop: disable RSpec/AnyInstance
+        allow(Time).to receive(:now).and_return(Time.zone.parse('2023-01-01 00:00:00 +0700'))
+
+        expect { upload_form.save }.to have_enqueued_job(SearchKeywordJob).at(5.seconds.from_now).exactly(295).times
       end
     end
 


### PR DESCRIPTION
- Close #26 
- Close #29 

## What happened 👀

Make sure we're able to scrape the raw HTML for multiple keywords (and store it in the html_code field).

## Insight 📝

Since Google blocked massive searches in a short time from a client, there are several approaches to bypass the search blocking:

- Add the delay between jobs: Random number in seconds in range 1 second to 10 minutes (1..600) ✅ 

```
    results.map(&:id).each do |id|
      delay_in_seconds = rand(1..600).seconds # Maximum delay is 10 minutes
      SearchKeywordJob.set(wait: delay_in_seconds).perform_later(id)
    end
```
- Add UserAgent generated randomly ✅ 

```
    def generate_user_agent
      Ronin::Web::UserAgents.chrome.random
    end
```

- ~~Add the X-forwarded-for with fake IP addresses into the header~~ ✅ 
  - Since adding delay between jobs is sufficient so we could get rid of this approach

- Proxy: Free proxy server changes frequently so can’t use this 🚫 

## Proof Of Work 📹

**GOOGLE**
Total of keywords: 295
Success results: 170

https://github.com/nimblehq/ic-rails-huey-toby/assets/6950766/d53eee8a-f5b0-495b-98d8-623e7d016172

**BING**
Total of keywords: 300
Success results: All, but some of them had to retry

https://github.com/nimblehq/ic-rails-huey-toby/assets/18277915/bd1ed041-a4d1-425f-aa5b-d9d313f03753

