### PR TITLE
[#6] [Backend] As a user, I can sign-up with e-mail and password

### DIFF
--- a/app/controllers/api/v1/search_results_controller.rb
+++ b/app/controllers/api/v1/search_results_controller.rb
@@ -26,10 +26,10 @@ module Api
       end
 
       def render_success(search_results)
-        data = SearchResultsSerializer.new(search_results).serializable_hash[:data]
-        message = I18n.t('activemodel.notices.models.search_result.create')
+        success_message = I18n.t('activemodel.notices.models.search_result.create')
+        search_results_data = SearchResultsSerializer.new(search_results, meta: { message: success_message })
 
-        render json: { data: data, meta: { message: message } }, status: :created
+        render json: search_results_data, status: :created
       end
 
       def render_failed(upload_form)

--- a/app/controllers/api/v1/search_results_controller.rb
+++ b/app/controllers/api/v1/search_results_controller.rb
@@ -33,6 +33,7 @@ module Api
       end
 
       def render_failed(upload_form)
+        # TODO: return error messages in JSON:API format
         render json: { errors: upload_form.errors.full_messages }, status: :unprocessable_entity
       end
     end

--- a/app/controllers/api/v1/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/api/v1/users/omniauth_callbacks_controller.rb
@@ -4,14 +4,11 @@ module Api
   module V1
     module Users
       class OmniauthCallbacksController < Devise::OmniauthCallbacksController
-        rescue_from Exception, with: :render_error
-
         respond_to :json
 
         def google_oauth2
           user = User.from_omniauth(auth)
-
-          render_success(user)
+          user.errors.empty? ? render_success(user) : render_error(user)
         end
 
         private
@@ -27,8 +24,8 @@ module Api
           render json: { data: token_data }, status: :ok
         end
 
-        def render_error(exception)
-          render json: { error: exception.message }, status: :internal_server_error
+        def render_error(user)
+          render json: { errors: user.errors.full_messages }, status: :internal_server_error
         end
       end
     end

--- a/app/controllers/api/v1/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/api/v1/users/omniauth_callbacks_controller.rb
@@ -8,7 +8,11 @@ module Api
 
         def google_oauth2
           user = User.from_omniauth(auth)
-          user.errors.empty? ? render_success(user) : render_error(user)
+          if user.errors.empty?
+            render_success(user)
+          else
+            render_error(user)
+          end
         end
 
         private
@@ -19,9 +23,9 @@ module Api
 
         def render_success(user)
           oauth_token = OauthToken.generate_access_token(user)
-          token_data = OauthTokenSerializer.new(oauth_token).serializable_hash[:data]
+          token_data = OauthTokenSerializer.new(oauth_token)
 
-          render json: { data: token_data }, status: :ok
+          render json: token_data, status: :ok
         end
 
         def render_error(user)

--- a/app/controllers/api/v1/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/api/v1/users/omniauth_callbacks_controller.rb
@@ -8,6 +8,7 @@ module Api
 
         def google_oauth2
           user = User.from_omniauth(auth)
+
           if user.errors.empty?
             render_success(user)
           else

--- a/app/controllers/api/v1/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/api/v1/users/omniauth_callbacks_controller.rb
@@ -29,6 +29,7 @@ module Api
         end
 
         def render_error(user)
+          # TODO: return error messages in JSON:API format
           render json: { errors: user.errors.full_messages }, status: :internal_server_error
         end
       end

--- a/app/controllers/api/v1/users/registrations_controller.rb
+++ b/app/controllers/api/v1/users/registrations_controller.rb
@@ -31,10 +31,14 @@ module Api
         end
 
         def render_error(user)
+          # TODO: return error messages in JSON:API format
+
           render json: { errors: user.errors.full_messages }, status: :unprocessable_entity
         end
 
         def ensure_valid_client
+          # TODO: return error messages in JSON:API format
+
           @client_app = Doorkeeper::Application.by_uid_and_secret(params[:client_id], params[:client_secret])
 
           render json: { errors: I18n.t('doorkeeper.errors.messages.invalid_client') }, status: :forbidden if @client_app.blank?

--- a/app/controllers/api/v1/users/registrations_controller.rb
+++ b/app/controllers/api/v1/users/registrations_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Users
+      class RegistrationsController < Devise::RegistrationsController
+        respond_to :json
+
+        before_action :ensure_valid_client
+
+        def create
+          user = User.from_email(user_params[:email], user_params[:password])
+          user.errors.empty? ? render_success(user) : render_error(user)
+        end
+
+        private
+
+        def user_params
+          params.require(:user).permit(:email, :password)
+        end
+
+        def render_success(user)
+          data = UserSerializer.new(user).serializable_hash[:data]
+          message = I18n.t('activemodel.notices.models.user.create')
+
+          render json: { data: data, meta: { message: message } }, status: :created
+        end
+
+        def render_error(user)
+          render json: { errors: user.errors.full_messages }, status: :unprocessable_entity
+        end
+
+        def ensure_valid_client
+          @client_app = Doorkeeper::Application.by_uid_and_secret(params[:client_id], params[:client_secret])
+
+          render json: { errors: I18n.t('doorkeeper.errors.messages.invalid_client') }, status: :forbidden if @client_app.blank?
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/users/registrations_controller.rb
+++ b/app/controllers/api/v1/users/registrations_controller.rb
@@ -10,6 +10,7 @@ module Api
 
         def create
           user = User.from_email(user_params[:email], user_params[:password])
+
           if user.errors.empty?
             render_success(user)
           else
@@ -39,9 +40,9 @@ module Api
         def ensure_valid_client
           # TODO: return error messages in JSON:API format
 
-          @client_app = Doorkeeper::Application.by_uid_and_secret(params[:client_id], params[:client_secret])
+          client_app = Doorkeeper::Application.by_uid_and_secret(params[:client_id], params[:client_secret])
 
-          render json: { errors: I18n.t('doorkeeper.errors.messages.invalid_client') }, status: :forbidden if @client_app.blank?
+          render json: { errors: I18n.t('doorkeeper.errors.messages.invalid_client') }, status: :forbidden if client_app.blank?
         end
       end
     end

--- a/app/controllers/api/v1/users/registrations_controller.rb
+++ b/app/controllers/api/v1/users/registrations_controller.rb
@@ -10,7 +10,11 @@ module Api
 
         def create
           user = User.from_email(user_params[:email], user_params[:password])
-          user.errors.empty? ? render_success(user) : render_error(user)
+          if user.errors.empty?
+            render_success(user)
+          else
+            render_error(user)
+          end
         end
 
         private
@@ -20,10 +24,10 @@ module Api
         end
 
         def render_success(user)
-          data = UserSerializer.new(user).serializable_hash[:data]
-          message = I18n.t('activemodel.notices.models.user.create')
+          success_message = I18n.t('activemodel.notices.models.user.create')
+          user_data = UserSerializer.new(user, meta: { message: success_message })
 
-          render json: { data: data, meta: { message: message } }, status: :created
+          render json: user_data, status: :created
         end
 
         def render_error(user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,36 +23,19 @@ class User < ApplicationRecord
 
   class << self
     def from_email(email, password)
-      user = find_or_initialize_user(
+      User.create(
         email: email,
         password: password,
         provider: User.providers[:email]
       )
-
-      user.persisted? ? user.errors.add(:email, :taken) : user.save
-
-      user
     end
 
     def from_omniauth(auth)
-      user = find_or_initialize_user(
-        email: auth.info.email,
-        password: Devise.friendly_token[0, 20],
-        provider: auth.provider,
-        auth: auth
-      )
-
-      user.provider == User.providers[:email] ? user.errors.add(:email, :taken) : user.persisted? || user.save
-
-      user
-    end
-
-    def find_or_initialize_user(email:, password:, provider:, auth: nil)
-      User.find_or_initialize_by(email: email) do |new_user|
+      User.find_or_create_by(email: auth.info.email, provider: auth.provider) do |new_user|
         new_user.assign_attributes(
-          email: email,
-          password: password,
-          provider: provider,
+          email: auth.info.email,
+          password: Devise.friendly_token[0, 20],
+          provider: auth.provider,
           provider_uid: auth&.uid,
           full_name: auth&.info&.name,
           avatar_url: auth&.info&.image

--- a/app/serializers/application_serializer.rb
+++ b/app/serializers/application_serializer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ApplicationSerializer
+  include JSONAPI::Serializer
+end

--- a/app/serializers/oauth_token_serializer.rb
+++ b/app/serializers/oauth_token_serializer.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-class OauthTokenSerializer
-  include JSONAPI::Serializer
-
+class OauthTokenSerializer < ApplicationSerializer
   attributes :token, :token_type, :refresh_token, :expires_in, :created_at
 end

--- a/app/serializers/search_results_serializer.rb
+++ b/app/serializers/search_results_serializer.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-class SearchResultsSerializer
-  include JSONAPI::Serializer
-
+class SearchResultsSerializer < ApplicationSerializer
   attributes :keyword, :search_engine, :status
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-class UserSerializer
-  include JSONAPI::Serializer
-
+class UserSerializer < ApplicationSerializer
   attributes :email, :full_name, :avatar_url, :provider, :provider_uid
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class UserSerializer
+  include JSONAPI::Serializer
+
+  attributes :email, :full_name, :avatar_url, :provider, :provider_uid
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -29,8 +29,6 @@ Devise.setup do |config|
   # with default "from" parameter.
   config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
 
-  config.omniauth :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET'], provider_ignores_state: true
-
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
 
@@ -184,7 +182,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 8..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly
@@ -278,6 +276,7 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+  config.omniauth :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET'], provider_ignores_state: true
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/locales/activemodel.en.yml
+++ b/config/locales/activemodel.en.yml
@@ -4,6 +4,8 @@ en:
       models:
         search_result:
           create: "Upload success, please wait for the results."
+        user:
+          create: "User was successfully registered, please confirm your e-mail."
     errors:
       models:
         upload_form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
       resources :upload, only: [:create], controller: 'search_results'
 
       devise_for :users, controllers: {
+        registrations: 'api/v1/users/registrations',
         omniauth_callbacks: 'api/v1/users/omniauth_callbacks'
       }
 

--- a/db/migrate/20230710023912_rename_uid_for_users.rb
+++ b/db/migrate/20230710023912_rename_uid_for_users.rb
@@ -1,0 +1,5 @@
+class RenameUidForUsers < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :users, :uid, :provider_uid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_07_07_024057) do
+ActiveRecord::Schema.define(version: 2023_07_10_023912) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -77,7 +77,7 @@ ActiveRecord::Schema.define(version: 2023_07_07_024057) do
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "full_name"
-    t.string "uid"
+    t.string "provider_uid"
     t.string "avatar_url"
     t.string "provider"
     t.string "reset_password_token"

--- a/spec/fabricators/application_fabricator.rb
+++ b/spec/fabricators/application_fabricator.rb
@@ -2,5 +2,7 @@
 
 Fabricator(:application, from: 'Doorkeeper::Application') do
   name { Faker::App.name }
+  uid { 'client_id' }
+  secret { 'client_secret' }
   redirect_uri { Faker::Internet.url(scheme: 'https') }
 end

--- a/spec/fabricators/user_fabricator.rb
+++ b/spec/fabricators/user_fabricator.rb
@@ -2,8 +2,8 @@
 
 Fabricator(:user) do
   id { Faker::Number.digit }
-  provider { Faker::Omniauth.google['provider'] }
-  uid { Faker::Omniauth.google['uid'] }
+  provider { Faker::Omniauth.google[:provider] }
+  provider_uid { Faker::Omniauth.google[:uid] }
   email { Faker::Internet.email }
   password { Faker::Internet.password }
   full_name { Faker::Name.name }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,17 +5,14 @@ require 'rails_helper'
 RSpec.describe User, type: :model do
   describe '.from_email' do
     context 'given an existing user is found' do
-      it 'returns the existing user' do
+      it 'returns an error' do
         email = Faker::Internet.email
         password = Faker::Internet.password
-        user = Fabricate(:user,
-                         provider: described_class.providers[:email],
-                         provider_uid: nil,
-                         email: email,
-                         full_name: nil,
-                         avatar_url: nil)
 
-        expect(described_class.from_email(email, password)).to eq(user)
+        described_class.from_email(email, password)
+        user = described_class.from_email(email, password)
+
+        expect(user.errors[:email]).to include('has already been taken')
       end
     end
 
@@ -39,12 +36,8 @@ RSpec.describe User, type: :model do
     context 'given an existing user is found' do
       it 'returns the existing user' do
         auth = OmniAuth::AuthHash.new(Faker::Omniauth.google)
-        user = Fabricate(:user,
-                         provider: auth['provider'],
-                         provider_uid: auth['uid'],
-                         email: auth['info']['email'],
-                         full_name: auth['info']['name'],
-                         avatar_url: auth['info']['image'])
+
+        user = described_class.from_omniauth(auth)
 
         expect(described_class.from_omniauth(auth)).to eq(user)
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,13 +3,45 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+  describe '.from_email' do
+    context 'given an existing user is found' do
+      it 'returns the existing user' do
+        email = Faker::Internet.email
+        password = Faker::Internet.password
+        user = Fabricate(:user,
+                         provider: described_class.providers[:email],
+                         provider_uid: nil,
+                         email: email,
+                         full_name: nil,
+                         avatar_url: nil)
+
+        expect(described_class.from_email(email, password)).to eq(user)
+      end
+    end
+
+    context 'given a new user' do
+      it 'creates a new user with the provided attributes' do
+        email = Faker::Internet.email
+        password = Faker::Internet.password
+
+        user = described_class.from_email(email, password)
+
+        expect(user.provider).to eq(described_class.providers[:email])
+        expect(user.provider_uid).to be_nil
+        expect(user.email).to eq(email)
+        expect(user.full_name).to be_nil
+        expect(user.avatar_url).to be_nil
+      end
+    end
+  end
+
   describe '.from_omniauth' do
     context 'given an existing user is found' do
       it 'returns the existing user' do
         auth = OmniAuth::AuthHash.new(Faker::Omniauth.google)
         user = Fabricate(:user,
                          provider: auth['provider'],
-                         uid: auth['uid'],
+                         provider_uid: auth['uid'],
                          email: auth['info']['email'],
                          full_name: auth['info']['name'],
                          avatar_url: auth['info']['image'])
@@ -25,7 +57,7 @@ RSpec.describe User, type: :model do
         user = described_class.from_omniauth(auth)
 
         expect(user.provider).to eq(auth['provider'])
-        expect(user.uid).to eq(auth['uid'])
+        expect(user.provider_uid).to eq(auth['uid'])
         expect(user.email).to eq(auth['info']['email'])
         expect(user.full_name).to eq(auth['info']['name'])
         expect(user.avatar_url).to eq(auth['info']['image'])

--- a/spec/requests/registrations_controller_spec.rb
+++ b/spec/requests/registrations_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Registrations', type: :request do
   describe 'POST #create' do
-    context 'given the email is NOT already taken' do
+    context 'given the email is available' do
       it 'renders a sign-up successful response' do
         application = Fabricate(:application)
         allow(Doorkeeper::Application).to receive(:first).and_return(application)
@@ -23,7 +23,7 @@ RSpec.describe 'Registrations', type: :request do
       end
     end
 
-    context 'given the email is already taken' do
+    context 'given the email is NOT available' do
       it 'returns an 422 error' do
         application = Fabricate(:application)
         allow(Doorkeeper::Application).to receive(:first).and_return(application)
@@ -43,7 +43,7 @@ RSpec.describe 'Registrations', type: :request do
       end
     end
 
-    context 'given the wrong client' do
+    context 'given the client is NOT correct' do
       it 'returns an 403 error' do
         application = Fabricate(:application)
         allow(Doorkeeper::Application).to receive(:first).and_return(application)

--- a/spec/requests/registrations_controller_spec.rb
+++ b/spec/requests/registrations_controller_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Registrations', type: :request do
+  describe 'POST #create' do
+    context 'given the email is NOT already taken' do
+      it 'renders a sign-up successful response' do
+        application = Fabricate(:application)
+        allow(Doorkeeper::Application).to receive(:first).and_return(application)
+
+        user = Fabricate(:user)
+        allow(User).to receive(:from_email).and_return(user)
+
+        post '/api/v1/users', params: {
+          user: { email: user.email, password: user.password },
+          client_id: 'client_id',
+          client_secret: 'client_secret'
+        }
+
+        expect(response).to have_http_status(:success)
+        expect(JSON.parse(response.body)['data']['type']).to eq('user')
+      end
+    end
+
+    context 'given the email is already taken' do
+      it 'returns an 422 error' do
+        application = Fabricate(:application)
+        allow(Doorkeeper::Application).to receive(:first).and_return(application)
+
+        user = Fabricate(:user)
+        user.errors.add(:email, :taken)
+        allow(User).to receive(:from_email).and_return(user)
+
+        post '/api/v1/users', params: {
+          user: { email: user.email, password: user.password },
+          client_id: 'client_id',
+          client_secret: 'client_secret'
+        }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(user.errors[:email]).to include('has already been taken')
+      end
+    end
+
+    context 'given the wrong client' do
+      it 'returns an 403 error' do
+        application = Fabricate(:application)
+        allow(Doorkeeper::Application).to receive(:first).and_return(application)
+
+        user = Fabricate(:user)
+        allow(User).to receive(:from_email).and_return(user)
+
+        post '/api/v1/users', params: {
+          user: { email: user.email, password: user.password },
+          client_id: 'incorrect_client_id',
+          client_secret: 'incorrect_client_secret'
+        }
+
+        expect(response).to have_http_status(:forbidden)
+        expect(JSON.parse(response.body)['errors']).to eq(I18n.t('doorkeeper.errors.messages.invalid_client'))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Close #6

## What happened 👀

- Added sign-up for email/password (the provider can be either `email` or `google_oauth2`)

For the sake of simplicity, I've decided to follow [@olivierobert's suggestion](https://nimble-co.slack.com/archives/C058GEPCT7F/p1688700310152069?thread_ts=1688634166.293839&cid=C058GEPCT7F).

*This means there can only be one user for one e-mail*, an error message will be returned otherwise.

- Also added `client_id` & `client_secret` authorization through `doorkeeper` (they are required in the body request)

## Proof Of Work 📹

https://github.com/nimblehq/ic-rails-huey-toby/assets/18277915/94153688-006d-4718-a48f-a20b661d8215

