### PR TITLE
[#17] [Backend] As a user, I can filter which search results contain a word in Adwords URLs

### DIFF
--- a/app/controllers/api/v1/search_results_controller.rb
+++ b/app/controllers/api/v1/search_results_controller.rb
@@ -22,11 +22,7 @@ module Api
       end
 
       def index
-        search_result_list = SearchResultsQuery.new(
-          current_user.search_results, {
-            url_equals: filter_params[:url_equals]
-          }
-        ).call
+        search_result_list = create_search_results_query
 
         pagy, paginated_results = paginated_resources_for(search_result_list)
 
@@ -36,6 +32,15 @@ module Api
       end
 
       private
+
+      def create_search_results_query
+        SearchResultsQuery.new(
+          current_user.search_results, {
+            url_equals: filter_params[:url_equals],
+            adwords_url_contains: filter_params[:adwords_url_contains]
+          }
+        ).call
+      end
 
       def upload_form
         @upload_form ||= UploadForm.new(
@@ -50,7 +55,7 @@ module Api
       end
 
       def filter_params
-        params.fetch(:filter, {}).permit(:url_equals)
+        params.fetch(:filter, {}).permit(:url_equals, :adwords_url_contains)
       end
     end
   end

--- a/app/queries/search_results_query.rb
+++ b/app/queries/search_results_query.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class SearchResultsQuery
-  attr_reader :search_results, :filters, :sorts
+  attr_reader :search_results, :filters
 
   CONDITION_URL_EQUALS = ':url = ANY (adwords_top_urls) OR :url = ANY (non_adwords_urls)'
+  CONDITION_ADWORDS_URL_CONTAINS = "array_to_string(adwords_top_urls, ', ') LIKE :word"
 
   def initialize(search_results = nil, filters = {})
     @search_results = search_results || SearchResult.all
@@ -12,6 +13,7 @@ class SearchResultsQuery
 
   def call
     @search_results = filter_by_url(filters[:url_equals])
+    @search_results = filter_adwords_url_contains(filters[:adwords_url_contains])
 
     @search_results
   end
@@ -19,6 +21,14 @@ class SearchResultsQuery
   def filter_by_url(url)
     if url.present?
       @search_results.where(CONDITION_URL_EQUALS, url: url)
+    else
+      @search_results
+    end
+  end
+
+  def filter_adwords_url_contains(word)
+    if word.present?
+      @search_results.where(CONDITION_ADWORDS_URL_CONTAINS, word: "%#{word}%")
     else
       @search_results
     end

--- a/spec/queries/search_results_query_spec.rb
+++ b/spec/queries/search_results_query_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe SearchResultsQuery, type: :model do
         user = Fabricate(:user)
 
         # Expected matches
-        Fabricate(:search_result, user_id: user.id, non_adwords_urls: ['wwww.nimblehq.co'])
-        Fabricate(:search_result, user_id: user.id, adwords_top_urls: ['wwww.nimblehq.co'])
-        Fabricate(:search_result, user_id: user.id, non_adwords_urls: ['wwww.nimblehq.co/compass'])
-        Fabricate(:search_result, user_id: user.id, adwords_top_urls: ['wwww.nimblehq.co/compass'])
+        Fabricate(:search_result, user_id: user.id, non_adwords_urls: ['www.nimblehq.co'])
+        Fabricate(:search_result, user_id: user.id, adwords_top_urls: ['www.nimblehq.co'])
+        Fabricate(:search_result, user_id: user.id, non_adwords_urls: ['www.nimblehq.co/compass'])
+        Fabricate(:search_result, user_id: user.id, adwords_top_urls: ['www.nimblehq.co/compass'])
 
         search_results_query = described_class.new
 
@@ -27,18 +27,38 @@ RSpec.describe SearchResultsQuery, type: :model do
         user = Fabricate(:user)
 
         # Expected matches
-        Fabricate(:search_result, user_id: user.id, non_adwords_urls: ['wwww.nimblehq.co'])
-        Fabricate(:search_result, user_id: user.id, adwords_top_urls: ['wwww.nimblehq.co'])
+        Fabricate(:search_result, user_id: user.id, non_adwords_urls: ['www.nimblehq.co'])
+        Fabricate(:search_result, user_id: user.id, adwords_top_urls: ['www.nimblehq.co'])
 
         # Non-matches
-        Fabricate(:search_result, user_id: user.id, non_adwords_urls: ['wwww.nimblehq.co/compass'])
-        Fabricate(:search_result, user_id: user.id, adwords_top_urls: ['wwww.nimblehq.co/compass'])
+        Fabricate(:search_result, user_id: user.id, non_adwords_urls: ['www.nimblehq.co/compass'])
+        Fabricate(:search_result, user_id: user.id, adwords_top_urls: ['www.nimblehq.co/compass'])
 
-        search_results_query = described_class.new(nil, { url_equals: 'wwww.nimblehq.co' })
+        search_results_query = described_class.new(nil, { url_equals: 'www.nimblehq.co' })
 
         search_results_query.call
 
         expect(search_results_query.search_results.count).to eq 2
+      end
+    end
+
+    context 'given adwords_url_contains filter' do
+      it 'returns only the search results which contain the word' do
+        user = Fabricate(:user)
+
+        # Expected matches
+        Fabricate(:search_result, user_id: user.id, adwords_top_urls: ['www.nimblehq.co/compass'])
+
+        # Non-matches
+        Fabricate(:search_result, user_id: user.id, non_adwords_urls: ['www.nimblehq.co/compass'])
+        Fabricate(:search_result, user_id: user.id, non_adwords_urls: ['www.nimblehq.co'])
+        Fabricate(:search_result, user_id: user.id, adwords_top_urls: ['www.nimblehq.co'])
+
+        search_results_query = described_class.new(nil, { adwords_url_contains: 'compass' })
+
+        search_results_query.call
+
+        expect(search_results_query.search_results.count).to eq 1
       end
     end
   end


### PR DESCRIPTION
Close #17

## What happened 👀

Add filter to return search results which have a word containing inside `adwords_top_urls`

## Insight 📝

The `LIKE` operator which is used to check if a string contains a word, can't be used on an array. 

As a solution, I convert the array of strings to a string first, before using the `LIKE` operator
 
**Note:** It's crucial to surround the word with `%`  inside the query
 
## Proof Of Work 📹


https://github.com/nimblehq/ic-rails-huey-toby/assets/18277915/f77d24eb-e28d-4bd6-b139-e49b58e7e7c2

