### PR TITLE
[#21][Backend] As a user, I can filter which search results contain a specific amount of characters

### DIFF
--- a/app/controllers/api/v1/search_results_controller.rb
+++ b/app/controllers/api/v1/search_results_controller.rb
@@ -46,8 +46,8 @@ module Api
           current_user.search_results, {
             url_equals: filter_params[:url_equals],
             adwords_url_contains: filter_params[:adwords_url_contains],
-            url_contains_at_least_one: filter_params[:url_contains_at_least_one],
-            url_contains_at_least_two: filter_params[:url_contains_at_least_two]
+            url_contains: filter_params[:url_contains],
+            match_count: filter_params[:match_count]
           }
         ).call
       end
@@ -65,8 +65,8 @@ module Api
       end
 
       def filter_params
-        params.fetch(:filter, {}).permit(:url_equals, :adwords_url_contains, :url_contains_at_least_one,
-                                         :url_contains_at_least_two)
+        params.fetch(:filter, {}).permit(:url_equals, :adwords_url_contains, :url_contains,
+                                         :match_count)
       end
 
       def upload_meta(search_result_list:)

--- a/app/controllers/api/v1/search_results_controller.rb
+++ b/app/controllers/api/v1/search_results_controller.rb
@@ -45,7 +45,9 @@ module Api
         SearchResultsQuery.new(
           current_user.search_results, {
             url_equals: filter_params[:url_equals],
-            adwords_url_contains: filter_params[:adwords_url_contains]
+            adwords_url_contains: filter_params[:adwords_url_contains],
+            url_contains_at_least_one: filter_params[:url_contains_at_least_one],
+            url_contains_at_least_two: filter_params[:url_contains_at_least_two]
           }
         ).call
       end
@@ -63,7 +65,8 @@ module Api
       end
 
       def filter_params
-        params.fetch(:filter, {}).permit(:url_equals, :adwords_url_contains)
+        params.fetch(:filter, {}).permit(:url_equals, :adwords_url_contains, :url_contains_at_least_one,
+                                         :url_contains_at_least_two)
       end
 
       def upload_meta(search_result_list:)

--- a/app/controllers/api/v1/search_results_controller.rb
+++ b/app/controllers/api/v1/search_results_controller.rb
@@ -65,8 +65,9 @@ module Api
       end
 
       def filter_params
-        params.fetch(:filter, {}).permit(:url_equals, :adwords_url_contains, :url_contains,
-                                         :match_count)
+        params
+          .fetch(:filter, {})
+          .permit(:url_equals, :adwords_url_contains, :url_contains, :match_count)
       end
 
       def upload_meta(search_result_list:)

--- a/app/queries/search_results_query.rb
+++ b/app/queries/search_results_query.rb
@@ -7,20 +7,22 @@ class SearchResultsQuery
   CONDITION_ADWORDS_URL_CONTAINS = "array_to_string(adwords_top_urls, ', ') LIKE :word"
 
   def initialize(search_results = nil, filters = {})
-    @search_results = search_results || SearchResult.all
+    @search_results = search_results || SearchResult.order(:id).all
     @filters = filters
   end
 
   def call
     @search_results = filter_by_url(filters[:url_equals])
     @search_results = filter_adwords_url_contains(filters[:adwords_url_contains])
+    @search_results = filter_urls_contains_at_least(filters[:url_contains_at_least_one], 1)
+    @search_results = filter_urls_contains_at_least(filters[:url_contains_at_least_two], 2)
 
     @search_results
   end
 
   def filter_by_url(url)
     if url.present?
-      @search_results.where(CONDITION_URL_EQUALS, url: url)
+      @search_results.where(CONDITION_URL_EQUALS, url: url).order(:id)
     else
       @search_results
     end
@@ -28,7 +30,20 @@ class SearchResultsQuery
 
   def filter_adwords_url_contains(word)
     if word.present?
-      @search_results.where(CONDITION_ADWORDS_URL_CONTAINS, word: "%#{word}%")
+      @search_results.where(CONDITION_ADWORDS_URL_CONTAINS, word: "%#{word}%").order(:id)
+    else
+      @search_results
+    end
+  end
+
+  def filter_urls_contains_at_least(character, count = 1)
+    if character.present?
+      search_result_ids = @search_results.select do |search_result|
+        search_result.adwords_top_urls.any? { |url| url.scan(character).count >= count } ||
+          search_result.non_adwords_urls.any? { |url| url.scan(character).count >= count }
+      end.pluck(:id)
+
+      @search_results.where(id: search_result_ids).order(:id)
     else
       @search_results
     end

--- a/app/queries/search_results_query.rb
+++ b/app/queries/search_results_query.rb
@@ -39,13 +39,19 @@ class SearchResultsQuery
   def filter_urls_contains_at_least(character, count = 1)
     if character.present?
       search_result_ids = @search_results.select do |search_result|
-        search_result.adwords_top_urls.any? { |url| url.scan(character).count >= count } ||
-          search_result.non_adwords_urls.any? { |url| url.scan(character).count >= count }
+        at_least_character_count?(search_result.adwords_top_urls, character, count) ||
+          at_least_character_count?(search_result.non_adwords_urls, character, count)
       end.pluck(:id)
 
       @search_results.where(id: search_result_ids).order(:id)
     else
       @search_results
     end
+  end
+
+  private
+
+  def at_least_character_count?(urls, character, count)
+    urls.any? { |url| url.scan(character).count >= count }
   end
 end

--- a/app/queries/search_results_query.rb
+++ b/app/queries/search_results_query.rb
@@ -14,7 +14,7 @@ class SearchResultsQuery
   def call
     @search_results = filter_by_url(filters[:url_equals])
     @search_results = filter_adwords_url_contains(filters[:adwords_url_contains])
-    @search_results = filter_urls_contains_at_least(filters[:url_contains], filters[:match_count])
+    @search_results = filter_urls_contains_at_least(filters[:url_contains], filters[:match_count] || 1)
 
     @search_results.order(:id)
   end
@@ -35,7 +35,7 @@ class SearchResultsQuery
     end
   end
 
-  def filter_urls_contains_at_least(word, match_count = 1)
+  def filter_urls_contains_at_least(word, match_count)
     if word.present?
       search_result_ids = @search_results.select do |search_result|
         urls = search_result.adwords_top_urls + search_result.non_adwords_urls

--- a/app/queries/search_results_query.rb
+++ b/app/queries/search_results_query.rb
@@ -35,22 +35,17 @@ class SearchResultsQuery
     end
   end
 
-  def filter_urls_contains_at_least(character, match_count = 1)
-    if character.present?
+  def filter_urls_contains_at_least(word, match_count = 1)
+    if word.present?
       search_result_ids = @search_results.select do |search_result|
-        at_least_character_count?(search_result.adwords_top_urls, character, match_count) ||
-          at_least_character_count?(search_result.non_adwords_urls, character, match_count)
+        urls = search_result.adwords_top_urls + search_result.non_adwords_urls
+
+        urls&.any? { |url| url.scan(word).count >= match_count.to_i }
       end.pluck(:id)
 
       @search_results.where(id: search_result_ids)
     else
       @search_results
     end
-  end
-
-  private
-
-  def at_least_character_count?(urls, character, match_count)
-    urls&.any? { |url| url.scan(character).count >= match_count.to_i }
   end
 end

--- a/app/serializers/search_result_list_serializer.rb
+++ b/app/serializers/search_result_list_serializer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class SearchResultListSerializer < ApplicationSerializer
-  attributes :keyword, :search_engine, :status
+  attributes :keyword, :search_engine, :status, :non_adwords_urls, :adwords_top_urls
 end

--- a/spec/queries/search_results_query_spec.rb
+++ b/spec/queries/search_results_query_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe SearchResultsQuery, type: :model do
       end
 
       context 'given match_count filter is NOT nil' do
-        it 'returns only the search results which contain a specific word at least for the define occurrence match count' do
+        it 'returns only the search results which contain a specific word at least for the defined occurrence match count' do
           user = Fabricate(:user)
 
           # Expected matches

--- a/spec/queries/search_results_query_spec.rb
+++ b/spec/queries/search_results_query_spec.rb
@@ -63,8 +63,8 @@ RSpec.describe SearchResultsQuery, type: :model do
     end
 
     context 'given filter_urls_contains filter' do
-      context 'given filter_match_count at least one filter' do
-        it 'returns only the search results which contain the character' do
+      context 'given match_count filter is nil' do
+        it 'returns only the search results which contain specific word at least once' do
           user = Fabricate(:user)
 
           # Expected matches
@@ -75,7 +75,7 @@ RSpec.describe SearchResultsQuery, type: :model do
           Fabricate(:search_result, user_id: user.id, non_adwords_urls: ['www.nimblehq.co'], adwords_top_urls: [])
           Fabricate(:search_result, user_id: user.id, non_adwords_urls: [], adwords_top_urls: ['www.nimblehq.co'])
 
-          search_results_query = described_class.new(nil, { url_contains: '/', match_count: 1 })
+          search_results_query = described_class.new(nil, { url_contains: '/' })
 
           search_results_query.call
 
@@ -83,8 +83,8 @@ RSpec.describe SearchResultsQuery, type: :model do
         end
       end
 
-      context 'given filter_match_count at least two filter' do
-        it 'returns only the search results which contain the character' do
+      context 'given match_count filter is NOT nil' do
+        it 'returns only the search results which contain a specific word at least for the define occurrence match count' do
           user = Fabricate(:user)
 
           # Expected matches
@@ -103,7 +103,7 @@ RSpec.describe SearchResultsQuery, type: :model do
         end
       end
 
-      it 'returns empty when the urls does NOT match the character' do
+      it 'returns empty when the urls does NOT match a specific word' do
         user = Fabricate(:user)
 
         # Expected matches

--- a/spec/queries/search_results_query_spec.rb
+++ b/spec/queries/search_results_query_spec.rb
@@ -62,8 +62,8 @@ RSpec.describe SearchResultsQuery, type: :model do
       end
     end
 
-    context 'given filter_urls_contains_at_least filter' do
-      context 'given filter_urls_contains_at_least_one filter' do
+    context 'given filter_urls_contains filter' do
+      context 'given filter_match_count at least one filter' do
         it 'returns only the search results which contain the character' do
           user = Fabricate(:user)
 
@@ -75,33 +75,15 @@ RSpec.describe SearchResultsQuery, type: :model do
           Fabricate(:search_result, user_id: user.id, non_adwords_urls: ['www.nimblehq.co'], adwords_top_urls: [])
           Fabricate(:search_result, user_id: user.id, non_adwords_urls: [], adwords_top_urls: ['www.nimblehq.co'])
 
-          search_results_query = described_class.new(nil, { url_contains_at_least_one: '/' })
+          search_results_query = described_class.new(nil, { url_contains: '/', match_count: 1 })
 
           search_results_query.call
 
           expect(search_results_query.search_results.count).to eq 2
         end
-
-        it 'returns empty when the urls does NOT match the character' do
-          user = Fabricate(:user)
-
-          # Expected matches
-          Fabricate(:search_result, user_id: user.id, non_adwords_urls: [], adwords_top_urls: ['www.nimblehq.co/compass'])
-          Fabricate(:search_result, user_id: user.id, non_adwords_urls: ['www.nimblehq.co/compass'], adwords_top_urls: [])
-
-          # Non-matches
-          Fabricate(:search_result, user_id: user.id, non_adwords_urls: ['www.nimblehq.co'], adwords_top_urls: [])
-          Fabricate(:search_result, user_id: user.id, non_adwords_urls: [], adwords_top_urls: ['www.nimblehq.co'])
-
-          search_results_query = described_class.new(nil, { url_contains_at_least_one: '>' })
-
-          search_results_query.call
-
-          expect(search_results_query.search_results.count).to eq 0
-        end
       end
 
-      context 'given filter_urls_contains_at_least_two filter' do
+      context 'given filter_match_count at least two filter' do
         it 'returns only the search results which contain the character' do
           user = Fabricate(:user)
 
@@ -113,12 +95,30 @@ RSpec.describe SearchResultsQuery, type: :model do
           Fabricate(:search_result, user_id: user.id, non_adwords_urls: ['www.nimblehq.co/compass'], adwords_top_urls: [])
           Fabricate(:search_result, user_id: user.id, non_adwords_urls: [], adwords_top_urls: ['www.nimblehq.co'])
 
-          search_results_query = described_class.new(nil, { url_contains_at_least_two: '/' })
+          search_results_query = described_class.new(nil, { url_contains: '/', match_count: 2 })
 
           search_results_query.call
 
           expect(search_results_query.search_results.count).to eq 2
         end
+      end
+
+      it 'returns empty when the urls does NOT match the character' do
+        user = Fabricate(:user)
+
+        # Expected matches
+        Fabricate(:search_result, user_id: user.id, non_adwords_urls: [], adwords_top_urls: ['www.nimblehq.co/compass'])
+        Fabricate(:search_result, user_id: user.id, non_adwords_urls: ['www.nimblehq.co/compass'], adwords_top_urls: [])
+
+        # Non-matches
+        Fabricate(:search_result, user_id: user.id, non_adwords_urls: ['www.nimblehq.co'], adwords_top_urls: [])
+        Fabricate(:search_result, user_id: user.id, non_adwords_urls: [], adwords_top_urls: ['www.nimblehq.co'])
+
+        search_results_query = described_class.new(nil, { url_contains: '>', match_count: 1 })
+
+        search_results_query.call
+
+        expect(search_results_query.search_results.count).to eq 0
       end
     end
   end

--- a/spec/queries/search_results_query_spec.rb
+++ b/spec/queries/search_results_query_spec.rb
@@ -61,5 +61,65 @@ RSpec.describe SearchResultsQuery, type: :model do
         expect(search_results_query.search_results.count).to eq 1
       end
     end
+
+    context 'given filter_urls_contains_at_least filter' do
+      context 'given filter_urls_contains_at_least_one filter' do
+        it 'returns only the search results which contain the character' do
+          user = Fabricate(:user)
+
+          # Expected matches
+          Fabricate(:search_result, user_id: user.id, non_adwords_urls: [], adwords_top_urls: ['www.nimblehq.co/compass'])
+          Fabricate(:search_result, user_id: user.id, non_adwords_urls: ['www.nimblehq.co/compass'], adwords_top_urls: [])
+
+          # Non-matches
+          Fabricate(:search_result, user_id: user.id, non_adwords_urls: ['www.nimblehq.co'], adwords_top_urls: [])
+          Fabricate(:search_result, user_id: user.id, non_adwords_urls: [], adwords_top_urls: ['www.nimblehq.co'])
+
+          search_results_query = described_class.new(nil, { url_contains_at_least_one: '/' })
+
+          search_results_query.call
+
+          expect(search_results_query.search_results.count).to eq 2
+        end
+
+        it 'returns empty when the urls does NOT match the character' do
+          user = Fabricate(:user)
+
+          # Expected matches
+          Fabricate(:search_result, user_id: user.id, non_adwords_urls: [], adwords_top_urls: ['www.nimblehq.co/compass'])
+          Fabricate(:search_result, user_id: user.id, non_adwords_urls: ['www.nimblehq.co/compass'], adwords_top_urls: [])
+
+          # Non-matches
+          Fabricate(:search_result, user_id: user.id, non_adwords_urls: ['www.nimblehq.co'], adwords_top_urls: [])
+          Fabricate(:search_result, user_id: user.id, non_adwords_urls: [], adwords_top_urls: ['www.nimblehq.co'])
+
+          search_results_query = described_class.new(nil, { url_contains_at_least_one: '>' })
+
+          search_results_query.call
+
+          expect(search_results_query.search_results.count).to eq 0
+        end
+      end
+
+      context 'given filter_urls_contains_at_least_two filter' do
+        it 'returns only the search results which contain the character' do
+          user = Fabricate(:user)
+
+          # Expected matches
+          Fabricate(:search_result, user_id: user.id, non_adwords_urls: [], adwords_top_urls: ['www.nimblehq.co/compass/development/code-conventions'])
+          Fabricate(:search_result, user_id: user.id, non_adwords_urls: ['www.nimblehq.co/compass/development'], adwords_top_urls: [])
+
+          # Non-matches
+          Fabricate(:search_result, user_id: user.id, non_adwords_urls: ['www.nimblehq.co/compass'], adwords_top_urls: [])
+          Fabricate(:search_result, user_id: user.id, non_adwords_urls: [], adwords_top_urls: ['www.nimblehq.co'])
+
+          search_results_query = described_class.new(nil, { url_contains_at_least_two: '/' })
+
+          search_results_query.call
+
+          expect(search_results_query.search_results.count).to eq 2
+        end
+      end
+    end
   end
 end

--- a/spec/requests/search_results_controller_spec.rb
+++ b/spec/requests/search_results_controller_spec.rb
@@ -84,15 +84,67 @@ RSpec.describe 'Search Results', type: :request do
         user = Fabricate(:user)
 
         # Expected matches
-        Fabricate(:search_result, user_id: user.id, non_adwords_urls: ['wwww.nimblehq.co'])
-        Fabricate(:search_result, user_id: user.id, adwords_top_urls: ['wwww.nimblehq.co'])
+        Fabricate(:search_result, user_id: user.id, non_adwords_urls: ['www.nimblehq.co'])
+        Fabricate(:search_result, user_id: user.id, adwords_top_urls: ['www.nimblehq.co'])
 
         # Non-matches
-        Fabricate(:search_result, user_id: user.id, non_adwords_urls: ['wwww.nimblehq.co/compass'])
-        Fabricate(:search_result, user_id: user.id, adwords_top_urls: ['wwww.nimblehq.co/compass'])
+        Fabricate(:search_result, user_id: user.id, non_adwords_urls: ['www.nimblehq.co/compass'])
+        Fabricate(:search_result, user_id: user.id, adwords_top_urls: ['www.nimblehq.co/compass'])
 
         authorization_header = create_authorization_header(user: user)
-        params = { page: { number: 1, size: 20 }, filter: { url_equals: 'wwww.nimblehq.co' } }
+        params = { page: { number: 1, size: 20 }, filter: { url_equals: 'www.nimblehq.co' } }
+
+        get '/api/v1/search_results', headers: authorization_header, params: params
+
+        expect(JSON.parse(response.body)['data'][0]['type']).to eq('search_result_list')
+        expect(JSON.parse(response.body)['meta']['page']).to eq(1)
+        expect(JSON.parse(response.body)['meta']['pages']).to eq(1)
+        expect(JSON.parse(response.body)['meta']['page_size']).to eq(20)
+        expect(JSON.parse(response.body)['meta']['records']).to eq(2)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'given a valid params with url_contains_at_least_one filter' do
+      it 'returns a successful response with JSON' do
+        user = Fabricate(:user)
+
+        # Expected matches
+        Fabricate(:search_result, user_id: user.id, non_adwords_urls: [], adwords_top_urls: ['www.nimblehq.co/compass'])
+        Fabricate(:search_result, user_id: user.id, non_adwords_urls: ['www.nimblehq.co/compass'], adwords_top_urls: [])
+
+        # Non-matches
+        Fabricate(:search_result, user_id: user.id, non_adwords_urls: ['www.nimblehq.co'], adwords_top_urls: [])
+        Fabricate(:search_result, user_id: user.id, non_adwords_urls: [], adwords_top_urls: ['www.nimblehq.co'])
+
+        authorization_header = create_authorization_header(user: user)
+        params = { page: { number: 1, size: 20 }, filter: { url_contains_at_least_one: '/' } }
+
+        get '/api/v1/search_results', headers: authorization_header, params: params
+
+        expect(JSON.parse(response.body)['data'][0]['type']).to eq('search_result_list')
+        expect(JSON.parse(response.body)['meta']['page']).to eq(1)
+        expect(JSON.parse(response.body)['meta']['pages']).to eq(1)
+        expect(JSON.parse(response.body)['meta']['page_size']).to eq(20)
+        expect(JSON.parse(response.body)['meta']['records']).to eq(2)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'given a valid params with url_contains_at_least_two filter' do
+      it 'returns a successful response with JSON' do
+        user = Fabricate(:user)
+
+        # Expected matches
+        Fabricate(:search_result, user_id: user.id, non_adwords_urls: ['www.nimblehq.co/compass/development/code-conventions'], adwords_top_urls: [])
+        Fabricate(:search_result, user_id: user.id, non_adwords_urls: ['www.nimblehq.co/compass/development'], adwords_top_urls: [])
+
+        # Non-matches
+        Fabricate(:search_result, user_id: user.id, non_adwords_urls: [], adwords_top_urls: ['www.nimblehq.co/compass'])
+        Fabricate(:search_result, user_id: user.id, non_adwords_urls: [], adwords_top_urls: ['www.nimblehq.co'])
+
+        authorization_header = create_authorization_header(user: user)
+        params = { page: { number: 1, size: 20 }, filter: { url_contains_at_least_two: '/' } }
 
         get '/api/v1/search_results', headers: authorization_header, params: params
 

--- a/spec/requests/search_results_controller_spec.rb
+++ b/spec/requests/search_results_controller_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe 'Search Results', type: :request do
         Fabricate(:search_result, user_id: user.id, non_adwords_urls: [], adwords_top_urls: ['www.nimblehq.co'])
 
         authorization_header = create_authorization_header(user: user)
-        params = { page: { number: 1, size: 20 }, filter: { url_contains_at_least_one: '/' } }
+        params = { page: { number: 1, size: 20 }, filter: { url_contains: '/', match_count: 1 } }
 
         get '/api/v1/search_results', headers: authorization_header, params: params
 
@@ -144,7 +144,7 @@ RSpec.describe 'Search Results', type: :request do
         Fabricate(:search_result, user_id: user.id, non_adwords_urls: [], adwords_top_urls: ['www.nimblehq.co'])
 
         authorization_header = create_authorization_header(user: user)
-        params = { page: { number: 1, size: 20 }, filter: { url_contains_at_least_two: '/' } }
+        params = { page: { number: 1, size: 20 }, filter: { url_contains: '/', match_count: 2 } }
 
         get '/api/v1/search_results', headers: authorization_header, params: params
 


### PR DESCRIPTION
- Close #21 

## What happened 👀

- Use the existing endpoint to filter: ~~`GET api/v1/search_results?filter[url_contains_at_least_two]={character}`~~ `GET api/v1/search_results?filter[url_contains]={character}&filter[match_count]={number}`

    - **Header**: Authorization (bearer token)
    -  **Request**: ~~`filter[url_contains_at_least_two]={character}`~~ `filter[url_contains]={character}&filter[match_count]={number}`
    - **Response**: List of search results

## Insight 📝

It's so tricky to look for `search_result` records which have URL containing a specific character by using the query. The alternative approach is filtering the urls match condition and then querying by the ids.

## Proof Of Work 📹

https://github.com/nimblehq/ic-rails-huey-toby/assets/6950766/2874dee2-d165-460e-9616-7606884a875f


